### PR TITLE
ci: fix github-publish.yml permissions

### DIFF
--- a/.github/workflows/github-publish.yml
+++ b/.github/workflows/github-publish.yml
@@ -6,14 +6,18 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   github-publish:
     name: github-publish
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+      uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
         registry-url: "https://npm.pkg.github.com"
@@ -27,4 +31,4 @@ jobs:
     - name: Publish package
       run: npm publish
       env:
-          NODE_AUTH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the new permissions syntax in workflow file, and use GITHUB_TOKEN to publish the package
