### PR TITLE
fix: modal options across open modal calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "modal",
     "useModal"
   ],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "lib/index",
   "types": "lib",
   "files": [

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -38,7 +38,7 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({
   const showModal = useCallback(
     (content: React.ReactNode, options?: Partial<ModalProps>) => {
       setContent(content);
-      if (options) optionsRef.current = options;
+      optionsRef.current = options;
     },
     [],
   );
@@ -47,10 +47,10 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({
     setContent(null);
   }, []);
 
-  const value = useMemo(() => ({ showModal, closeModal }), [
-    showModal,
-    closeModal,
-  ]);
+  const value = useMemo(
+    () => ({ showModal, closeModal }),
+    [showModal, closeModal],
+  );
 
   return (
     <ModalContext.Provider value={value}>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Resetting modal options on every showModal call
Issue: onModalHide callback of previous modal is getting called when the next modal is hidden

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
